### PR TITLE
refactor: use stable keys

### DIFF
--- a/app/more/page.tsx
+++ b/app/more/page.tsx
@@ -37,8 +37,8 @@ export default function More() {
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">gaming & socials</span>
                     <ul className="flex flex-col gap-1">
-                        {usernames.map((game, idx) => (
-                            <li key={idx} className="pl-3">
+                        {usernames.map((game) => (
+                            <li key={game.game} className="pl-3">
                                 <div>
                                     <span className="font-medium">{game.game}</span>
                                     <p className="text-neutral-600 transition-colors dark:text-neutral-400">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,8 +68,8 @@ export default function Home() {
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">experience</span>
                     <ul className="flex flex-col gap-1">
-                        {experience.map((exp, idx) => (
-                            <li key={idx} className="pl-3">
+                        {experience.map((exp) => (
+                            <li key={exp.company} className="pl-3">
                                 <div>
                                     <span className="font-medium">{exp.company}</span>{" "}
                                     <span className="text-neutral-700 transition-colors dark:text-neutral-300">
@@ -86,8 +86,8 @@ export default function Home() {
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">education</span>
                     <ul className="flex flex-col gap-1">
-                        {education.map((edu, idx) => (
-                            <li key={idx} className="pl-3">
+                        {education.map((edu) => (
+                            <li key={edu.institution} className="pl-3">
                                 <div>
                                     <span className="font-medium">{edu.institution}</span>{" "}
                                     <span className="text-neutral-700 transition-colors dark:text-neutral-300">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -98,8 +98,8 @@ export default function Projects() {
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">projects</span>
                     <ul className="flex flex-col gap-1">
-                        {projects.map((project, idx) => (
-                            <li key={idx} className="pl-3">
+                        {projects.map((project) => (
+                            <li key={project.name} className="pl-3">
                                 <div>
                                     <span className="font-medium">{project.name}</span>{" "}
                                     <span className="text-neutral-700 transition-colors dark:text-neutral-300">
@@ -110,7 +110,7 @@ export default function Projects() {
                                     </p>
                                     <p className="text-neutral-500 transition-colors dark:text-neutral-500">
                                         {project.links.map((link, linkIdx) => (
-                                            <span key={linkIdx}>
+                                            <span key={link.name}>
                                                 <a
                                                     href={link.url}
                                                     className="text-neutral-500 transition-colors hover:text-neutral-700 dark:text-neutral-500 dark:hover:text-neutral-300"


### PR DESCRIPTION
## Summary
- replace index-based React keys with stable identifiers across pages
- ensure source arrays use unique names for keys

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c173ea748325bbca3421b02182da