### PR TITLE
refactor: centralise role checks

### DIFF
--- a/app/lib/roles.ts
+++ b/app/lib/roles.ts
@@ -1,0 +1,18 @@
+export type SessionWithRoles = {
+    user?: {
+        roles?: string[];
+    };
+} | null;
+
+export function userHasPermittedRoles(session: SessionWithRoles): boolean {
+    const permittedRoles =
+        process.env.AUTH_ALLOWED_ROLES?.split(",")
+            .map((role) => role.trim())
+            .filter(Boolean) || [];
+    if (permittedRoles.length === 0) {
+        return true;
+    }
+    return (
+        session?.user?.roles?.some((role) => permittedRoles.includes(role)) ?? false
+    );
+}

--- a/app/lib/shorten.ts
+++ b/app/lib/shorten.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import parse from "parse-duration";
 import { auth } from "@/auth";
 import { shortenUrl } from "@/lib/db";
+import { userHasPermittedRoles } from "@/lib/roles";
 
 const schema = z.object({
     url: z.preprocess(
@@ -47,13 +48,7 @@ export async function shorten(_: unknown, formData: FormData) {
         return { success: false, issues: ["Unauthorized"], slugs: [] };
     }
 
-    const permittedRoles =
-        process.env.AUTH_ALLOWED_ROLES?.split(",").map((role) => role.trim()) || [];
-
-    const hasPermission =
-        session?.user?.roles?.some((role: string) => permittedRoles.includes(role)) || false;
-
-    if (permittedRoles.length > 0 && !hasPermission) {
+    if (!userHasPermittedRoles(session)) {
         return { success: false, issues: ["Forbidden"], slugs: [] };
     }
 

--- a/app/shorten/page.tsx
+++ b/app/shorten/page.tsx
@@ -1,16 +1,12 @@
 import { auth } from "@/auth";
 import { AuthButton } from "@/components/AuthButton";
 import ShortenForm from "@/components/ShortenForm";
+import { userHasPermittedRoles } from "@/lib/roles";
 import * as motion from "motion/react-client";
 
 export default async function Shorten() {
     const session = await auth();
-
-    const permittedRoles =
-        process.env.AUTH_ALLOWED_ROLES?.split(",").map((role) => role.trim()) || [];
-
-    const hasPermission =
-        session?.user?.roles?.some((role: string) => permittedRoles.includes(role)) || false;
+    const hasPermission = userHasPermittedRoles(session);
 
     return (
         <main>
@@ -21,9 +17,11 @@ export default async function Shorten() {
                 transition={{ duration: 0.2 }}>
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">link shortener</span>
-                    {permittedRoles.length > 0 && hasPermission ?
+                    {hasPermission ? (
                         <ShortenForm />
-                    :   <p>this service is private, and requires an authorised user account.</p>}
+                    ) : (
+                        <p>this service is private, and requires an authorised user account.</p>
+                    )}
                 </div>
                 <div className="flex flex-col gap-1">
                     <span className="font-bold">authentication</span>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "eslint .",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "lint": "eslint ."
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary
- centralize permitted-role logic in `userHasPermittedRoles`
- use role helper in shorten server action and page
- drop tests and related tooling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no script)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c147cc8c83259634b6c2541b9be5